### PR TITLE
Deduplicate package atom list

### DIFF
--- a/bug-assign.user.js
+++ b/bug-assign.user.js
@@ -165,7 +165,10 @@
             {
                 // strip the version if any
                 var cp = cpv.replace(/-\d+(\.\d+)*[a-z]?((_alpha|_beta|_pre|_rc|_p)\d*)?(-r\d+)?$/, '');
-                pnames.push(cp);
+                if (!pnames.includes(cp))
+                {
+                    pnames.push(cp);
+                }
             }
         }
 


### PR DESCRIPTION
Signed-off-by: John Helmert III <ajak@gentoo.org>

Sometimes curly bracket evaluations result in the same `cp` being in the list multiple times, this is a simple patch to avoid adding duplicate `cp`'s to the array. Simple test bug:

https://bugs.gentoo.org/784611