### PR TITLE
add link to packages.g.o for the package

### DIFF
--- a/bug-assign.user.js
+++ b/bug-assign.user.js
@@ -181,7 +181,7 @@
         var topbox = document.getElementById('bug-assign-table');
         topbox.innerHTML = '';
 
-        var tr, td, input;
+        var a, tr, td, input;
 
         // header row
         tr = document.createElement('tr');
@@ -211,8 +211,12 @@
             topbox.appendChild(tr);
 
             td = document.createElement('th');
-            if (pkg != '_special')
-                td.textContent = pkg;
+            if (pkg != '_special') {
+                a = document.createElement('a');
+                a.href = 'https://packages.gentoo.org/packages/' + pkg;
+                a.textContent = pkg;
+                td.appendChild(a);
+            }
             td.style = 'text-align: left; border-top: 1px dashed black';
             tr.appendChild(td);
 


### PR DESCRIPTION
Sometimes I want a fast way to access the packages.g.o of a package in bug, and this seems simple and effective place to get exactly that.